### PR TITLE
Clicking listing fixes

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -302,6 +302,10 @@ select {
   filter: opacity(0.7);
 }
 
+.listing-info.hidden {
+  display: none;
+}
+
 
 form {
   width: 80%;

--- a/static/script/script.js
+++ b/static/script/script.js
@@ -10,6 +10,8 @@ document.addEventListener("DOMContentLoaded", function() {
             var series = container.querySelector("p:nth-of-type(1)").textContent;
             var category = container.querySelector("p:nth-of-type(2)").textContent;
             var mrk_value = container.querySelector("p:nth-of-type(3)").textContent;
+            var userLink = container.querySelector(".listing-info a").href; // Get the user profile link
+            var user = container.querySelector(".listing-info a").textContent; // Get the
             var imageSrc = container.querySelector("img").src;
 
             // Update modal content
@@ -19,6 +21,7 @@ document.addEventListener("DOMContentLoaded", function() {
             var modalDetails = document.querySelector("#myModal .modal-content #modal-details");
             modalDetails.innerHTML = `
                 <img src="${imageSrc}" alt="${name}">
+                <p><a href="${userLink}">${user}</a></p>
                 <p>${series}</p>
                 <p>${category}</p>
                 <p>${mrk_value}</p>

--- a/static/script/script.js
+++ b/static/script/script.js
@@ -1,12 +1,12 @@
 document.addEventListener("DOMContentLoaded", function() {
     // Get all Sonny item containers
-    var sonnyContainers = document.querySelectorAll(".item-list li");
+    var sonnyContainers = document.querySelectorAll(".sonny_items_container");
 
     // Add click event listener to each Sonny item container
     sonnyContainers.forEach(function(container) {
         container.addEventListener("click", function() {
             // Get Sonny Angel details
-            var name = container.querySelector("h3").textContent;
+            var name = container.querySelector("h5").textContent;
             var series = container.querySelector("p:nth-of-type(1)").textContent;
             var category = container.querySelector("p:nth-of-type(2)").textContent;
             var mrk_value = container.querySelector("p:nth-of-type(3)").textContent;

--- a/templates/common.html
+++ b/templates/common.html
@@ -53,7 +53,7 @@
                         {% endfor %}
                     </div>
                     <!--Information for listing-->
-                    <div class="">
+                    <div class="listing-info hidden">
                         <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                         <p>
                             {{ item.series }}

--- a/templates/common.html
+++ b/templates/common.html
@@ -84,5 +84,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/discontinued.html
+++ b/templates/discontinued.html
@@ -57,7 +57,7 @@
                         {% endfor %}
                     </div>
                     <!--Information for listing-->
-                    <div class="">
+                    <div class="listing-info hidden">
                         <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                         <p>
                             {{ item.series }}

--- a/templates/discontinued.html
+++ b/templates/discontinued.html
@@ -89,5 +89,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
                                 {% endfor %}
                             </div>
                             <!--Information for listing-->
-                            <div class="">
+                            <div class="listing-info hidden">
                                 <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                                 <p>
                                     {{ item.series }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,5 +91,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/limited.html
+++ b/templates/limited.html
@@ -58,7 +58,7 @@
                                 {% endfor %}
                             </div>
                             <!--Information for listing-->
-                            <div class="">
+                            <div class="listing-info hidden">
                                 <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                                 <p>
                                     {{ item.series }}

--- a/templates/limited.html
+++ b/templates/limited.html
@@ -89,5 +89,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/robbie.html
+++ b/templates/robbie.html
@@ -90,5 +90,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/robbie.html
+++ b/templates/robbie.html
@@ -59,7 +59,7 @@
                                 {% endfor %}
                             </div>
                             <!--Information for listing-->
-                            <div class="">
+                            <div class="listing-info hidden">
                                 <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                                 <p>
                                     {{ item.series }}

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -88,5 +88,6 @@
         </div>
     </div>
 </div>
+<script src="static/script/script.js"></script>
 </body>
 </html>

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -57,7 +57,7 @@
                                 {% endfor %}
                             </div>
                             <!--Information for listing-->
-                            <div class="">
+                            <div class="listing-info hidden">
                                 <a href="{{ url_for('user_profile', username=item.user) }}"> User: {{ item.user }} </a>
                                 <p>
                                     {{ item.series }}


### PR DESCRIPTION
Listings are clickable again and listing info is no longer visible on the main page. Listing info can be found after someone clicks on the item. A modal will pop up with details, including the user and their linked profile.